### PR TITLE
去除开发环境地址栏“webpack-dev-server”

### DIFF
--- a/src/util/webpackDevServer.js
+++ b/src/util/webpackDevServer.js
@@ -68,8 +68,8 @@ class WebpackDevServer {
         if (err) {
           logger.fatal(err);
         }
-        logger.success(`The server is running at http://${this.host}:${this.port}/webpack-dev-server/`);
-        open(`http://${this.host}:${this.port}/webpack-dev-server/`);
+        logger.success(`The server is running at http://${this.host}:${this.port}/`);
+        open(`http://${this.host}:${this.port}/`);
       });    
   }
 }


### PR DESCRIPTION
因为觉得没必要，有时候开发还是要观察路由变化的，每次启动都要删除地址栏的webpack-dev-server，给开发带来不必要的麻烦